### PR TITLE
Remove Cygwin in Windows documentation

### DIFF
--- a/userlib_sdk/Howto.md
+++ b/userlib_sdk/Howto.md
@@ -169,7 +169,7 @@ Load the compiler variables:
 
 #### Windows x64 Intel oneAPI: Compiler Environment
 
-OpenRadioss was tested with oneAPI 2023.2 + Visual Studio 2019. Cygwin is used to build OpenRadioss. 
+OpenRadioss was tested with oneAPI 2023.2 + Visual Studio 2019.
 Issues have been found with earlier oneAPI releases. It is not recommended to use previous versions.
 
 This chapter explains how to setup
@@ -236,7 +236,7 @@ This chapter explains how to setup
 
 #### Windows x64 mingw gfortran: Compiler Environment
 
-MinGW is a native GNU gcc/gfortran port for Windows. Cygwin will be used to build the SDK
+MinGW is a native GNU gcc/gfortran port for Windows.
 
 For more information, please visit [https://www.mingw-w64.org](https://www.mingw-w64.org)
 
@@ -273,7 +273,6 @@ For more information, please visit [https://www.mingw-w64.org](https://www.mingw
 6. Setup git
 
    This paragraph permits to to setup Git and use it with GitHub.
-   Launch cygwin build environment and apply the git configuration :
 
    * Add in Git global environment the autocrlf flag
 

--- a/userlib_sdk/build_script.bash
+++ b/userlib_sdk/build_script.bash
@@ -27,7 +27,7 @@ function my_help()
   echo " " 
   echo " Use with arguments : "
   echo " -arch=[linux64|linuxa64|win64]"
-  echo " -compiler=[armflang|gfortran|intel]"
+  echo " -compiler=[armflang|gfortran|oneapi|intel]"
   echo "            Defaults :"
   echo "              linux64  : gfortran"
   echo "              win64    : oneapi"

--- a/userlib_sdk/build_windows.bat
+++ b/userlib_sdk/build_windows.bat
@@ -100,7 +100,7 @@ if exist %build_directory% (
 
 call ..\source\Cmake_Compilers\cmake_%compiler%_compilers.bat
 
-cmake -G Ninja -Darch=%arch% -Dcompiler=%compiler% -Dprecision=%prec% -DCMAKE_Fortran_COMPILER=%fcomp% -DCMAKE_C_COMPILER=%ccomp% ..\source
+cmake -G Ninja -Darch=%arch% -Dcompiler=%compiler% -Dprecision=%prec% -DCMAKE_Fortran_COMPILER=%fcomp% -DCMAKE_C_COMPILER=%ccomp%  -DCMAKE_CXX_COMPILER=%ccomp% ..\source
 ninja %verbose% 
 
 copy *.lib ..\userlib_sdk\%sdk_directory% >nul 2>nul
@@ -118,7 +118,7 @@ goto END_SCRIPT
   echo.
   echo  Use with arguments : 
   echo  -arch=[linux64, linuxa64, win64]
-  echo  -compiler=[armflang, gfortran, intel]
+  echo  -compiler=[armflang, gfortran, oneapi, intel]
   echo             Defaults :
   echo               linux64  : gfortran
   echo               win64    : oneapi


### PR DESCRIPTION
Documentation :
Still 2 reference to Cygwin.
Issue on Windows on ; some cmake versions cause check issues.