### PR TITLE
Correction of prop and part ids for spring connectors

### DIFF
--- a/input_converters/inp2rad/inp2rad/inp2rad.py
+++ b/input_converters/inp2rad/inp2rad/inp2rad.py
@@ -1422,6 +1422,9 @@ def convert_props(input_lines, material_names):
             property_names[property_name]['nint'] = '555'
             property_names[property_name]['conntype'] = conntype
             property_names[property_name]['material_id'] = 0
+            # Increment the property ID
+            prop_id += 1
+
 
         elif section_type == 'solid':
             # Assign a property ID to the property


### PR DESCRIPTION
where there were multiple *SECTION CONNECTOR in inp, all were being given the same (duplicate) prop id and part id due to error in the way this was incremented for spring parts, this corrects by adding a prop id increment in the connector creation