### PR TITLE
correction of impuse value derivation for section

### DIFF
--- a/output_converters/th_to_csv/src/th_to_csv.c
+++ b/output_converters/th_to_csv/src/th_to_csv.c
@@ -1270,7 +1270,7 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
                 outpuType != 6) ||
                 ((strcmp(buffer,"F1        ")==0 || strcmp(buffer,"F2        ")==0 || strcmp(buffer,"F3        ")==0 ||
                     strcmp(buffer,"M1        ")==0 || strcmp(buffer,"M2        ")==0 || strcmp(buffer,"M3        ")==0 ) && 
-                outpuType == 102) )
+                outpuType == 104) )
             {
                 isImpulse[i]=1;
             }


### PR DESCRIPTION
F1/F2/F3 M1/M2/M3 are not valid for outpuType=102 ( RBODY) but, it is for sectionx (outpuType = 104)
No need to add MX/MY/MZ ,, it is already well handle

