### PR TITLE
fix path separator in `input_converters/inp2rad/install.sh`

### DIFF
--- a/input_converters/inp2rad/install.sh
+++ b/input_converters/inp2rad/install.sh
@@ -4,6 +4,6 @@ cd inp2rad
 pip3 install .
 cd ..
 cd build
-pyinstaller --onefile ..\inp2rad\inp2rad.py
+pyinstaller --onefile ../inp2rad/inp2rad.py
 python3 install.py
 cd ..


### PR DESCRIPTION
`install.sh` for `inp2rad` might not work due to wrong use of path separators (i.e., `\`). They should be replaced into `/`.