### PR TITLE
add global variable 16 in th to csv tool

### DIFF
--- a/output_converters/th_to_csv/src/th_to_csv.c
+++ b/output_converters/th_to_csv/src/th_to_csv.c
@@ -1194,11 +1194,16 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
     fprintf(csvFile,"\"CONTACT ENERGY\",");
     fprintf(csvFile,"\"HOURGLASS ENERGY\",");
 
-    if (*nbglobVar == 15)
+    if (*nbglobVar >= 15)
     {
         fprintf(csvFile,"\"ELASTIC CONTACT ENERGY\",");
         fprintf(csvFile,"\"FRICTIONAL CONTACT ENERGY\",");
         fprintf(csvFile,"\"DAMPING CONTACT ENERGY \",");
+    }
+    
+    if (*nbglobVar >= 16)
+    {
+        fprintf(csvFile,"\"PLASTIC WORK\",");
     }
 
     if (!titlesFile)


### PR DESCRIPTION
This pull request updates the logic for writing column headers in the CSV output to better support cases where the number of global variables (`nbglobVar`) is greater than or equal to 15, and adds support for a new variable when `nbglobVar` is at least 16.

**CSV header logic improvements:**

* Changed the condition for writing the "ELASTIC CONTACT ENERGY", "FRICTIONAL CONTACT ENERGY", and "DAMPING CONTACT ENERGY" headers to trigger when `*nbglobVar` is greater than or equal to 15, instead of exactly 15.
* Added a new condition to write the "PLASTIC WORK" header when `*nbglobVar` is greater than or equal to 16.