### PR TITLE
Detect build errors & spread them to the script.

### DIFF
--- a/output_converters/anim_to_vtk/linux64/build.bash
+++ b/output_converters/anim_to_vtk/linux64/build.bash
@@ -10,4 +10,18 @@ fi
 
 
  g++ -DLINUX -o ../../../exec/anim_to_vtk_linux64_gf ../src/anim_to_vtk.cpp
+ export BUILD_RETURN_CODE=$?
+ if [ $BUILD_RETURN_CODE -ne 0 ]
+ then
+    echo " " 
+    echo "Build failed"
+    echo " " 
+    rm -f *.o
+    exit $BUILD_RETURN_CODE
+ fi
 
+ echo " " 
+ echo "Build succeeded"
+ echo " "
+ rm -f *.o
+ exit 0

--- a/output_converters/anim_to_vtk/linuxa64/build.bash
+++ b/output_converters/anim_to_vtk/linuxa64/build.bash
@@ -10,4 +10,19 @@ fi
 
 
  g++ -DLINUX -o ../../../exec/anim_to_vtk_linuxa64 ../src/anim_to_vtk.cpp
+ export BUILD_RETURN_CODE=$?
+ if [ $BUILD_RETURN_CODE -ne 0 ]
+ then
+    echo " " 
+    echo "Build failed"
+    echo " " 
+    rm -f *.o
+    exit $BUILD_RETURN_CODE
+ fi
+
+ echo " " 
+ echo "Build succeeded"
+ echo " "
+ rm -f *.o
+ exit 0
 

--- a/output_converters/anim_to_vtk/win64/build.bat
+++ b/output_converters/anim_to_vtk/win64/build.bat
@@ -7,4 +7,18 @@ if not exist ..\..\..\exec (
 
 cl -DWIN32 /Fe..\..\..\exec\anim_to_vtk_win64.exe ..\src\anim_to_vtk.cpp Ws2_32.lib
 
-del *.obj
+set error_var=%errorlevel%
+if %error_var%==0 (
+  echo.
+  echo Build succeeded
+  echo.
+  endlocal
+  del *.obj
+  exit /b %error_var%
+) else (
+  echo.
+  echo Build failed
+  echo.
+  endlocal
+  exit /b %error_var%
+)

--- a/output_converters/th_to_csv/linux64/build.bash
+++ b/output_converters/th_to_csv/linux64/build.bash
@@ -10,4 +10,18 @@ fi
 
 
  gcc -DLINUX -o ../../../exec/th_to_csv_linux64_gf ../src/th_to_csv.c
+ export BUILD_RETURN_CODE=$?
+ if [ $BUILD_RETURN_CODE -ne 0 ]
+ then
+    echo " " 
+    echo "Build failed"
+    echo " " 
+    rm -f *.o
+    exit $BUILD_RETURN_CODE
+ fi
 
+ echo " " 
+ echo "Build succeeded"
+ echo " "
+ rm -f *.o
+ exit 0

--- a/output_converters/th_to_csv/linuxa64/build.bash
+++ b/output_converters/th_to_csv/linuxa64/build.bash
@@ -10,4 +10,18 @@ fi
 
 
  gcc -DLINUX -o ../../../exec/th_to_csv_linuxa64 ../src/th_to_csv.c
+ export BUILD_RETURN_CODE=$?
+ if [ $BUILD_RETURN_CODE -ne 0 ]
+ then
+    echo " " 
+    echo "Build failed"
+    echo " " 
+    rm -f *.o
+    exit $BUILD_RETURN_CODE
+ fi
 
+ echo " " 
+ echo "Build succeeded"
+ echo " "
+ rm -f *.o
+ exit 0

--- a/output_converters/th_to_csv/win64/build.bat
+++ b/output_converters/th_to_csv/win64/build.bat
@@ -1,5 +1,5 @@
 echo off
-
+setlocal
 if not exist ..\..\..\exec (
   echo "--- Creating exec directory"
   mkdir ..\..\..\exec
@@ -7,4 +7,19 @@ if not exist ..\..\..\exec (
 
 cl /Fe..\..\..\exec\th_to_csv_win64.exe ..\src\th_to_csv.c
 
-del *.obj
+set error_var=%errorlevel%
+if %error_var%==0 (
+  echo.
+  echo Build succeeded
+  echo.
+  endlocal
+  del *.obj
+  exit /b %error_var%
+) else (
+  echo.
+  echo Build failed
+  echo.
+  endlocal
+  exit /b %error_var%
+)
+


### PR DESCRIPTION
Issues in converter builds:
When build error appears, the error is not transfered out of script.
Build procedures may not detect it.

