### PR TITLE
th_to_csv issue correction : number of global variables badly taken into account

### DIFF
--- a/output_converters/th_to_csv/src/th_to_csv.c
+++ b/output_converters/th_to_csv/src/th_to_csv.c
@@ -1192,13 +1192,29 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
     fprintf(csvFile,"\"EXTERNAL WORK\",");
     fprintf(csvFile,"\"SPRING ENERGY\",");
     fprintf(csvFile,"\"CONTACT ENERGY\",");
-    fprintf(csvFile,"\"HOURGLASS ENERGY\",");
-
-    if (*nbglobVar >= 15)
+    fprintf(csvFile,"\"HOURGLASS ENERGY\",");   
+    fprintf(csvFile,"\"ELASTIC CONTACT ENERGY\",");
+    fprintf(csvFile,"\"FRICTIONAL CONTACT ENERGY\",");
+    fprintf(csvFile,"\"DAMPING CONTACT ENERGY \",");
+    
+    if(*nbglobVar >= 16)
+        fprintf(csvFile,"\"PLASTIC WORK\",");
+    if(*nbglobVar >= 17)
+        fprintf(csvFile,"\"ADDED MASS\",");
+    if(*nbglobVar >= 18)
+        fprintf(csvFile,"\"PERCENTAGE ADDED MASS\",");
+    if(*nbglobVar >= 19)
+        fprintf(csvFile,"\"INLET MASS\",");
+    if(*nbglobVar >= 20)
+        fprintf(csvFile,"\"OUTLET MASS\",");
+    if(*nbglobVar >= 21)
+        fprintf(csvFile,"\"INLET ENERGY\",");
+    if(*nbglobVar >= 22)
+        fprintf(csvFile,"\"OUTLET ENERGY\",");
+    if(*nbglobVar >= 23)
     {
-        fprintf(csvFile,"\"ELASTIC CONTACT ENERGY\",");
-        fprintf(csvFile,"\"FRICTIONAL CONTACT ENERGY\",");
-        fprintf(csvFile,"\"DAMPING CONTACT ENERGY \",");
+        for(i=23;i<=*nbglobVar;i++)
+        fprintf(csvFile,"\"NO NAME\",");
     }
     
     if (*nbglobVar >= 16)


### PR DESCRIPTION
This pull request updates the CSV header generation logic in `th_to_csv.c` to support a variable number of global variables, making the output more flexible and future-proof. Instead of hardcoding the header for exactly 15 global variables, the code now conditionally adds headers for additional variables when present.

Enhancements to CSV header flexibility:

* Replaced the fixed check for 15 global variables with conditional statements that add new headers for each additional variable from 16 to 22, including `"PLASTIC WORK"`, `"ADDED MASS"`, `"PERCENTAGE ADDED MASS"`, `"INLET MASS"`, `"OUTLET MASS"`, `"INLET ENERGY"`, and `"OUTLET ENERGY"` as appropriate.
* For any global variables beyond 22, the code dynamically adds a `"NO NAME"` column for each extra variable, improving extensibility for future use cases.