### PR TITLE
Update minimum CMake version to allow build with modern CMake

### DIFF
--- a/userlib_sdk/source/CMakeLists.txt
+++ b/userlib_sdk/source/CMakeLists.txt
@@ -22,7 +22,7 @@
 # CMake project file for Radioss uselib sdk
 # ------------------------------------------
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.5)
 
 project (userlib_sdk)
 


### PR DESCRIPTION
Modern CMake versions (tested with 4.2) have dropped support of versions <3.5. With this change the build completes and there are no warnings