### PR TITLE
Fix TH-csv conversion failure for simulations in long Windows paths

### DIFF
--- a/openradioss_gui/runopenradioss.py
+++ b/openradioss_gui/runopenradioss.py
@@ -422,7 +422,7 @@ class RunOpenRadioss():
                 th_to_csv_exec =os.path.join("exec","th_to_csv_"+self.arch+self.bin_extension)
     
                 thtocsv_command = [ os.path.join(self.openradioss_path, th_to_csv_exec), 
-                                    os.path.join(self.running_directory, th_file)  ]
+                                    th_file  ]
                 # Redirect the output to the th-csv converter
                 subprocess.run(thtocsv_command, env=self.custom_env, cwd=self.running_directory)
 


### PR DESCRIPTION
This PR fixes a Windows GUI issue where TH-to-CSV conversion fails when simulation files are located in a long directory path.

The GUI already launches th_to_csv with cwd set to the simulation directory, but it was also passing the full absolute path to the T01 file. 
For long paths, th_to_csv_win64.exe appears to corrupt the derived _TITLES filename internally, causing errors such as duplicated path segments and T01_TITLES NOT FOUND.

This change passes only the local TH filename to the converter while keeping cwd=self.running_directory, avoiding the long absolute path argument.